### PR TITLE
replace obsolete API Complete() with complete() and update model llam…

### DIFF
--- a/module-1/call_transcript_analysis.ipynb
+++ b/module-1/call_transcript_analysis.ipynb
@@ -3,6 +3,14 @@
   "kernelspec": {
    "display_name": "Streamlit Notebook",
    "name": "streamlit"
+  },
+  "lastEditStatus": {
+   "notebookId": "zxsxjmtgvn2syijstqu4",
+   "authorId": "8065527255216",
+   "authorName": "BRALE",
+   "authorEmail": "braianquiceno555@gmail.com",
+   "sessionId": "3707d0b2-2afe-4325-813c-ec283072c333",
+   "lastEditTime": 1758611536637
   }
  },
  "nbformat_minor": 5,
@@ -70,7 +78,7 @@
     "resultHeight": 0
    },
    "outputs": [],
-   "source": "from snowflake.cortex import Complete\nprompt = \"\"\"\n    Summarize this transcript in less than 200 words. \nPut the product name, defect and summary in JSON format. \n\"\"\"",
+   "source": "from snowflake.cortex import complete\nprompt = \"\"\"\n    Summarize this transcript in less than 200 words. \nPut the product name, defect and summary in JSON format. \n\"\"\"",
    "execution_count": null
   },
   {
@@ -83,7 +91,7 @@
     "resultHeight": 945
    },
    "outputs": [],
-   "source": "print(Complete('llama3.2-1b', prompt + transcript))",
+   "source": "print(complete('llama4-maverick', prompt + transcript))",
    "execution_count": null
   },
   {
@@ -110,7 +118,7 @@
     "resultHeight": 561
    },
    "outputs": [],
-   "source": "from snowflake.cortex import Complete\ndef summarize():\n    with st.container():\n        st.header(\"JSON Summary\")\n        entered_text = st.text_area(\"Enter text\",label_visibility=\"hidden\",height=400,placeholder='Enter text. For example, a call transcript.')\n        btn_summarize = st.button(\"Summarize\",type=\"primary\")\n        if entered_text and btn_summarize:\n            entered_text = entered_text.replace(\"'\", \"\\\\'\")\n            prompt = f\"Summarize this transcript in less than 200 words. Put the product name, defect if any, and summary in JSON format: {entered_text}\"\n            cortex_prompt = \"'[INST] \" + prompt + \" [/INST]'\"\n            cortex_response = Complete(\"mistral-7b\", cortex_prompt + transcript)\n            st.json(cortex_response)\n\npage_names_to_funcs = {\n    \"JSON Summary\": summarize\n}\n\nselected_page = st.sidebar.selectbox(\"Select\", page_names_to_funcs.keys())\npage_names_to_funcs[selected_page]()",
+   "source": "from snowflake.cortex import complete\ndef summarize():\n    with st.container():\n        st.header(\"JSON Summary\")\n        entered_text = st.text_area(\"Enter text\",label_visibility=\"hidden\",height=400,placeholder='Enter text. For example, a call transcript.')\n        btn_summarize = st.button(\"Summarize\",type=\"primary\")\n        if entered_text and btn_summarize:\n            entered_text = entered_text.replace(\"'\", \"\\\\'\")\n            prompt = f\"Summarize this transcript in less than 200 words. Put the product name, defect if any, and summary in JSON format: {entered_text}\"\n            cortex_prompt = \"'[INST] \" + prompt + \" [/INST]'\"\n            cortex_response = complete(\"mistral-7b\", cortex_prompt + transcript)\n            st.json(cortex_response)\n\npage_names_to_funcs = {\n    \"JSON Summary\": summarize\n}\n\nselected_page = st.sidebar.selectbox(\"Select\", page_names_to_funcs.keys())\npage_names_to_funcs[selected_page]()",
    "execution_count": null
   },
   {


### PR DESCRIPTION
### Summary

Update Cortex AI examples in Python to use the current API and a supported model:

* `snowflake.cortex.Complete` ⟶ `snowflake.cortex.complete`.
* `llama3.2-1b` [Snowflake Cortex: Model deprecation](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_05/bcr-1984?utm_source=chatgpt.com) ⟶ `llama4-maverick`. 

### Motivation

Avoid warnings/errors due to using an obsolete API and model, making it easier for new users to run the notebook without friction.

### Changes

* Import in Python: `from snowflake.cortex import complete`.
* Function usage: `complete(‘<model>’, prompt)`.
* Default model in examples: `llama4-maverick` [Models available](https://docs.snowflake.com/en/sql-reference/functions/complete-snowflake-cortex#arguments).

### Impact

* **Does not** break compatibility with the rest of the code.
* Prevents runtime errors in current environments.

### How to test?

1. Open the updated notebook.
2. Run cells `cell_5`, `cell_6`, and `cell_8`.
3. Verify that it returns a response without deprecation warnings.